### PR TITLE
Write Swagger of ETASTE-API

### DIFF
--- a/swagger/openapi.yml
+++ b/swagger/openapi.yml
@@ -41,6 +41,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/Error'
+    delete:
+      tags: 
+        - store
+      summary: Delete Store.
+      operationId: deleteStore
+      parameters:
+      - name: storeId
+        in: path
+        description: Store Id.
+        required: true
+        schema:
+          type: integer
+          format: int64
+      responses:
+        '200':
+          description: Success Delete.
+        default:
+          description: Failed.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/Error'
   /store/detail/{storeId}:
     get:
       tags: 


### PR DESCRIPTION
fix #6 

### 内容
ETATE-API(store, food, favorite, user)をSwaggerでドキュメント化した

### 確認手順
[Swagger Editor](https://editor.swagger.io/)に、
openapi.ymlファイルをインポートする

### 備考
deal-APIと更新系のAPIはまだできていない
エラーコードとメッセージはまだ定義できていない
